### PR TITLE
add keep_days to prune old originals from .processed/

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ here will never leave a recording unprocessed.
 | `max_height` | Downscale tall videos to this height; `0` keeps the original | `0` |
 | `output_suffix` | Added to the output name. `{speed}` becomes the speed, so the name follows it | `-{speed}x` |
 | `keep_original` | `true` files the original in `.processed/`, `false` deletes it | `true` |
+| `keep_days` | Delete originals from `.processed/` once this many days old, up to 3650; `0` keeps them forever | `0` |
 | `notify` | Post a macOS banner when a file is done | `true` |
 | `notify_title` | Banner title | `Video optimized` |
 | `notify_sound` | `Glass`, `Ping`, `Pop`, `Hero` and the rest, or `none` | `Glass` |

--- a/settings.conf
+++ b/settings.conf
@@ -35,6 +35,10 @@ output_suffix = -{speed}x
 # Keep the original in a hidden .processed/ folder (true) or delete it (false).
 keep_original = true
 
+# Delete originals from .processed/ once they are this many days old. 0 keeps them forever;
+# anything above 3650 (10 years) is refused, the same way fps refuses anything above 240.
+keep_days = 0
+
 # Show a macOS banner when each file is done, and its title and sound.
 # Sounds: Glass, Ping, Pop, Hero, Submarine, Tink, Funk, Basso, Frog, Sosumi, or none.
 notify = true

--- a/shrinkit.sh
+++ b/shrinkit.sh
@@ -59,6 +59,7 @@ typeset -A DEFAULTS=(
   max_height 0              # downscale tall videos, 0 keeps the original size
   output_suffix '-{speed}x' # {speed} is filled in, so the name follows a speed change
   keep_original true        # move the source aside instead of deleting it
+  keep_days 0               # prune .processed/ older than this many days, 0 keeps it forever
   notify true
   notify_start true # also show a quiet banner when a file starts, not just when it finishes
   notify_title "Video optimized"
@@ -143,6 +144,12 @@ validate_config() {
   is_bool "${CFG[remove_audio]}" || reject remove_audio "want true or false"
   is_bool "${CFG[trim_idle]}" || reject trim_idle "want true or false"
   is_bool "${CFG[keep_original]}" || reject keep_original "want true or false"
+  # The digit count is bounded before the value ever reaches zsh arithmetic: a long enough digit
+  # string gets silently truncated there rather than rejected, and could slip through a bare
+  # <=3650 comparison at the wrong truncated value. Capped well short of where keep_days*86400
+  # overflows and wraps the cutoff into the future, which would prune everything in .processed/
+  # in one pass, freshly-archived files included.
+  [[ "${CFG[keep_days]}" =~ ^[0-9]{1,4}$ ]] && ((CFG[keep_days] <= 3650)) || reject keep_days "want 0-3650"
   is_bool "${CFG[notify]}" || reject notify "want true or false"
   is_bool "${CFG[notify_start]}" || reject notify_start "want true or false"
   is_bool "${CFG[copy_to_clipboard]}" || reject copy_to_clipboard "want true or false"
@@ -319,7 +326,9 @@ handle() {
   after="$(human_size "$out")"
 
   if [[ "${CFG[keep_original]}" == true ]]; then
-    mv "$src" "$DONE_DIR/"
+    # touch: mv keeps the recording's own mtime, but keep_days counts from when it was archived.
+    # touch: mv keeps the recording's own mtime, but keep_days counts from when it was archived.
+    mv "$src" "$DONE_DIR/" && touch "$DONE_DIR/${src:t}"
   else
     rm -f "$src"
   fi
@@ -372,6 +381,16 @@ process_queue() {
   done
 
   ((seen)) || log "nothing new to do"
+}
+
+# Epoch seconds, not zsh's (m+N): that counts calendar days, not 24h spans, and misjudged a 25h file here.
+prune_processed() {
+  ((CFG[keep_days] > 0)) || return 0
+  local cutoff=$(($(date +%s) - CFG[keep_days] * 86400)) file mtime
+  for file in "$DONE_DIR"/*(N.); do
+    mtime="$(stat -f%m "$file" 2> /dev/null)" || continue
+    ((mtime < cutoff)) && rm -f "$file" && log "pruned ${file:t} (older than ${CFG[keep_days]}d)"
+  done
 }
 
 # --------------------------------------------------------------------- update check
@@ -709,6 +728,7 @@ main() {
     return 0
   }
   process_queue
+  prune_processed
   check_for_updates
 }
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -286,6 +286,80 @@ test_keep_original_false_deletes_the_source() {
   check "deletes instead of filing" empty_dir "$box/.processed"
 }
 
+test_keep_days_prunes_old_originals() {
+  local box
+  box="$(sandbox)"
+  settings "$box" 'keep_days = 30'
+  cp "$FIXTURES/silent.mov" "$box/input/old.mov"
+  optimize "$box"
+  touch -t 200001010000 "$box/.processed/old.mov"
+
+  cp "$FIXTURES/silent.mov" "$box/input/fresh.mov"
+  optimize "$box"
+
+  check "prunes the old original" missing "$box/.processed/old.mov"
+  check "keeps the fresh one" exists "$box/.processed/fresh.mov"
+  check "says so in the log" logged "$box" 'pruned old.mov'
+}
+
+test_keep_days_counts_from_archiving_not_the_recording_date() {
+  local box
+  box="$(sandbox)"
+  settings "$box" 'keep_days = 30'
+  cp "$FIXTURES/silent.mov" "$box/input/old-recording.mov"
+  touch -t 200506070000 "$box/input/old-recording.mov" # made years ago, dropped in only today
+
+  optimize "$box"
+  check "archives it rather than pruning it on day one" exists "$box/.processed/old-recording.mov"
+}
+
+test_keep_days_too_large_is_rejected_not_truncated() {
+  local box
+  box="$(sandbox)"
+  # long enough that zsh's own arithmetic would truncate rather than reject a bare comparison
+  settings "$box" 'keep_days = 99999999999999999999999999999'
+  cp "$FIXTURES/silent.mov" "$box/input/clip.mov"
+  optimize "$box"
+  touch -t 200001010000 "$box/.processed/clip.mov"
+
+  cp "$FIXTURES/silent.mov" "$box/input/second.mov"
+  optimize "$box"
+
+  check "rejects it back to the default" logged "$box" "ignoring keep_days="
+  check "prunes nothing on the default" exists "$box/.processed/clip.mov"
+}
+
+test_keep_days_does_not_claim_a_removal_that_failed() {
+  local box
+  box="$(sandbox)"
+  settings "$box" 'keep_days = 5'
+  cp "$FIXTURES/silent.mov" "$box/input/locked.mov"
+  optimize "$box"
+  touch -t 200001010000 "$box/.processed/locked.mov"
+  chflags uchg "$box/.processed/locked.mov"
+
+  cp "$FIXTURES/silent.mov" "$box/input/second.mov"
+  optimize "$box"
+  chflags nouchg "$box/.processed/locked.mov"
+
+  check "leaves the locked file in place" exists "$box/.processed/locked.mov"
+  check "does not claim it was pruned" test "$(log_count "$box" 'pruned locked.mov')" = 0
+}
+
+test_keep_days_off_by_default() {
+  local box
+  box="$(sandbox)"
+  settings "$box" 'speed = 2'
+  cp "$FIXTURES/silent.mov" "$box/input/old.mov"
+  optimize "$box"
+  touch -t 200001010000 "$box/.processed/old.mov"
+
+  cp "$FIXTURES/silent.mov" "$box/input/second.mov"
+  optimize "$box"
+
+  check "leaves it alone" exists "$box/.processed/old.mov"
+}
+
 test_output_dir_redirect() {
   local box
   box="$(sandbox)"
@@ -372,12 +446,13 @@ test_an_old_json_config_is_reported() {
 test_bad_values_are_rejected_one_by_one() {
   local box
   box="$(sandbox)"
-  settings "$box" 'speed = abc' 'fps = 100000' 'crf = 99' 'codec = vp9' 'remove_audio = maybe' 'output_suffix = '
+  settings "$box" 'speed = abc' 'fps = 100000' 'crf = 99' 'codec = vp9' 'remove_audio = maybe' \
+    'output_suffix = ' 'keep_days = never'
   cp "$FIXTURES/silent.mov" "$box/input/clip.mov"
 
   optimize "$box"
   local key
-  for key in speed fps crf codec remove_audio output_suffix; do
+  for key in speed fps crf codec remove_audio output_suffix keep_days; do
     check "rejects a bad $key" logged "$box" "ignoring $key="
   done
   check "still encodes on the defaults" exists "$box/output/clip-2x.mp4"
@@ -697,6 +772,11 @@ TESTS=(
   test_trim_idle_stands_down_when_the_audio_is_kept
   test_downscale
   test_keep_original_false_deletes_the_source
+  test_keep_days_prunes_old_originals
+  test_keep_days_counts_from_archiving_not_the_recording_date
+  test_keep_days_too_large_is_rejected_not_truncated
+  test_keep_days_does_not_claim_a_removal_that_failed
+  test_keep_days_off_by_default
   test_output_dir_redirect
   test_skips_work_already_done
   test_ignores_things_that_are_not_videos


### PR DESCRIPTION
Closes #12.

`.processed/` archives every original recording forever right now, with no cleanup mechanism at all. `keep_days` deletes originals once they're this many days old; `0` (the default) keeps the current behavior exactly.

Went through an adversarial pass before opening this, since the failure mode of a prune feature is silently destroying someone's original recordings. Two real bugs came out of that and are fixed here, not left as follow-ups:

- **Integer overflow.** A large-but-well-formed `keep_days` (roughly 15+ digits) overflowed the cutoff arithmetic and wrapped it into the future, which pruned *everything* in `.processed/`, including a file archived in the same run. Fixed with a 3650-day cap, matching how `fps` is already capped. A plain `<= 3650` check on its own turned out to have the same hole: a long enough digit string gets truncated by zsh's arithmetic before the comparison runs, so the value is bounded by digit count first, before any arithmetic touches it.
- **A failed prune was logged as a successful one.** `rm -f` on a locked or permission-denied file still failed, but the log said "pruned" regardless, since the log line was written before the removal was attempted. Now it's written only once `rm -f` actually succeeds.

Also fixed along the way: `mv` preserves a file's original mtime on the same volume, so an old recording dropped in and archived *today* would have been pruned in that same run, before ever sitting in `.processed/` for the length of time `keep_days` implies. The archive step now stamps the file with today's date.

Two low-severity gaps found in the same pass are filed separately rather than fixed here: #15 (symlinks in `.processed/` are never pruned, no data-loss risk either way) and #16 (pruning a large one-time backlog is slow, correctness is fine). A third, a literal newline inside a filename splitting a log line, isn't realistic for anything a screen recorder actually produces and isn't tracked separately.

104 tests passing (was 100 on main), `shfmt` clean, smoke-tested against a live install.